### PR TITLE
Split init and update of host matrix from sparsity pattern

### DIFF
--- a/LduMatrix/GKOLduBase/GKOLduBase.H
+++ b/LduMatrix/GKOLduBase/GKOLduBase.H
@@ -88,8 +88,10 @@ public:
         // initially
         bool stored = get_sys_matrix_stored();
         if (!stored) {
+            SIMPLE_TIME(init_host_sparsity_pattern,
+                        this->init_host_sparsity_pattern();)
             std::cout << " matrix not stored update host matrix " << std::endl;
-            SIMPLE_TIME(update_host_mtx, this->update_host_matrix_copy();)
+            SIMPLE_TIME(update_host_mtx, this->update_host_matrix_data();)
         } else {
             // if sys_matrix is  stored updating is only neccesary
             // when requested explictly
@@ -98,7 +100,7 @@ public:
                 << std::endl;
             if (get_update_sys_matrix()) {
                 SIMPLE_TIME(exp_update_host_mtx,
-                            this->update_host_matrix_copy();)
+                            this->update_host_matrix_data();)
             }
         }
 
@@ -113,8 +115,11 @@ public:
         if (!stored && get_sort()) {
             std::cout << "matrix is not yet sorted,  sorting host matrix "
                       << std::endl;
+            SIMPLE_TIME(
+                sort_host_mtx_sparsity_pattern,
+                this->sort_host_matrix_sparsity_pattern(get_sorting_idxs());)
             SIMPLE_TIME(sort_host_mtx,
-                        this->sort_host_matrix_copy(this->get_sorting_idxs());)
+                        this->sort_host_matrix_data(this->get_sorting_idxs());)
         }
 
         init_device_matrix(matrix.mesh().thisDb(), this->values(),

--- a/common/common.H
+++ b/common/common.H
@@ -80,52 +80,77 @@ public:
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
           nElems_(nCells_ + 2 * nNeighbours_){};
 
-    void update_host_matrix_copy() const
+    void init_host_sparsity_pattern() const
     {
-        // reset vectors
-        values_.resize(0);
         col_idxs_.resize(0);
         row_idxs_.resize(0);
 
-        values_.reserve(nElems());
         col_idxs_.reserve(nElems());
         row_idxs_.reserve(nElems());
 
         // fill vectors unsorted
         for (label i = 0; i < nNeighbours(); ++i) {
-            values_.push_back(this->matrix().lower()[i]);
             row_idxs_.push_back(this->matrix().lduAddr().lowerAddr()[i]);
             col_idxs_.push_back(this->matrix().lduAddr().upperAddr()[i]);
         }
 
         for (label i = 0; i < nCells(); ++i) {
-            values_.push_back(this->matrix().diag()[i]);
             col_idxs_.push_back(i);
             row_idxs_.push_back(i);
         }
 
         for (label i = 0; i < nNeighbours(); ++i) {
-            values_.push_back(this->matrix().upper()[i]);
             row_idxs_.push_back(this->matrix().lduAddr().upperAddr()[i]);
             col_idxs_.push_back(this->matrix().lduAddr().lowerAddr()[i]);
         }
+    }
+
+    void update_host_matrix_data() const
+    {
+        // reset vectors
+        values_.resize(0);
+
+        values_.reserve(nElems());
+
+        // fill vectors unsorted
+        for (label i = 0; i < nNeighbours(); ++i) {
+            values_.push_back(this->matrix().lower()[i]);
+        }
+
+        for (label i = 0; i < nCells(); ++i) {
+            values_.push_back(this->matrix().diag()[i]);
+        }
+
+        for (label i = 0; i < nNeighbours(); ++i) {
+            values_.push_back(this->matrix().upper()[i]);
+        }
     };
 
-    void sort_host_matrix_copy(const IOField<label> *sorting_idxs) const
+    void sort_host_matrix_sparsity_pattern(
+        const IOField<label> *sorting_idxs) const
     {
-        std::vector<scalar> tmp_values(nElems());
         std::vector<label> tmp_col_idxs(nElems());
         std::vector<label> tmp_row_idxs(nElems());
 
-        for (label i = 0; i < nElems(); i++) tmp_values[i] = values_[i];
         for (label i = 0; i < nElems(); i++) tmp_col_idxs[i] = col_idxs_[i];
         for (label i = 0; i < nElems(); i++) tmp_row_idxs[i] = row_idxs_[i];
 
         for (label i = 0; i < nElems(); i++) {
             label j = sorting_idxs->operator[](i);
-            values_[i] = tmp_values[j];
             col_idxs_[i] = tmp_col_idxs[j];
             row_idxs_[i] = tmp_row_idxs[j];
+        }
+    };
+
+    void sort_host_matrix_data(const IOField<label> *sorting_idxs) const
+    {
+        std::vector<scalar> tmp_values(nElems());
+
+        for (label i = 0; i < nElems(); i++) tmp_values[i] = values_[i];
+
+        for (label i = 0; i < nElems(); i++) {
+            label j = sorting_idxs->operator[](i);
+            values_[i] = tmp_values[j];
         }
     };
 

--- a/lduMatrix/GKOlduBase/GKOlduBase.H
+++ b/lduMatrix/GKOlduBase/GKOlduBase.H
@@ -86,23 +86,33 @@ public:
         // initially
         bool stored = get_sys_matrix_stored();
         if (!stored) {
-            SIMPLE_TIME(update_host_mtx, update_host_matrix_copy();)
+            SIMPLE_TIME(init_host_sparsity_pattern,
+                        init_host_sparsity_pattern();)
+            SIMPLE_TIME(update_host_mtx, update_host_matrix_data();)
         } else {
             // if sys_matrix is  stored updating is only neccesary
             // when requested explictly
             if (get_update_sys_matrix()) {
-                SIMPLE_TIME(exp_update_host_mtx, update_host_matrix_copy();)
+                // since sparsity pattern should already be stored
+                // on device no init_host_sparsity_pattern call is needed
+                SIMPLE_TIME(exp_update_host_mtx, update_host_matrix_data();)
             }
         }
 
+        // TODO move compute_sorting_idxs in the if clause above to have all
+        // init calls together
         // after updating the host matrix the host matrix needs to be sorted
         if (!get_is_sorted()) {
-            SIMPLE_TIME(compute_sort, compute_sorting_idxs(row_idxs());)
+            SIMPLE_TIME(compute_sorting_idxs, compute_sorting_idxs(row_idxs());)
         }
 
+        // TODO move compute_sorting_idxs in the if clause above to have all
+        // init calls together
         if (!stored && get_sort()) {
-            SIMPLE_TIME(sort_host_mtx,
-                        sort_host_matrix_copy(get_sorting_idxs());)
+            SIMPLE_TIME(sort_host_mtx_sparsity_pattern,
+                        sort_host_matrix_sparsity_pattern(get_sorting_idxs());)
+            SIMPLE_TIME(sort_host_mtx_data,
+                        sort_host_matrix_data(get_sorting_idxs());)
         }
 
         init_device_matrix(matrix.mesh().thisDb(), values(), col_idxs(),


### PR DESCRIPTION
This PR splits initializing of the host sparsity pattern and host matrix data update to avoid recalculating the constant sparsity pattern when the  matrix data needs to be updated. 